### PR TITLE
Removing system cache included in flutter bundles

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,7 +60,8 @@ func main() {
 	log.SetEnableDebugLog(cfg.IsDebug)
 
 	if bundleSpecified && gitBranchSpecified {
-		log.Warnf("Input: 'Flutter SDK git repository version' (version) is ignored, using 'Flutter SDK installation bundle URL' (installation_bundle_url).")
+		log.Warnf("Input: 'Flutter SDK git repository version' (version) is ignored, " +
+			"using 'Flutter SDK installation bundle URL' (installation_bundle_url).")
 	}
 
 	preInstalled := true
@@ -87,9 +88,13 @@ func main() {
 	}
 
 	requiredVersion := strings.TrimSpace(cfg.Version)
-	if !cfg.IsUpdate && preInstalled && !bundleSpecified && requiredVersion == versionInfo.channel && sliceutil.IsStringInSlice(requiredVersion, []string{"stable", "beta", "dev", "master"}) {
-		log.Infof("Required Flutter channel (%s) matches preinstalled Flutter channel (%s), skipping installation.", requiredVersion, versionInfo.channel)
-		log.Infof(`Set input "Update to the latest version (is_update)" to "true" to use the latest version from channel %s.`, requiredVersion)
+	if !cfg.IsUpdate && preInstalled && !bundleSpecified &&
+		requiredVersion == versionInfo.channel &&
+		sliceutil.IsStringInSlice(requiredVersion, []string{"stable", "beta", "dev", "master"}) {
+		log.Infof("Required Flutter channel (%s) matches preinstalled Flutter channel (%s), skipping installation.",
+			requiredVersion, versionInfo.channel)
+		log.Infof(`Set input "Update to the latest version (is_update)" to "true"
+to use the latest version from channel %s.`, requiredVersion)
 
 		if cfg.IsDebug {
 			if err := runFlutterDoctor(); err != nil {
@@ -122,15 +127,9 @@ func main() {
 		if err := unarchiveBundle(cfg.BundleURL, sdkPathParent); err != nil {
 			failf("failed to download and unarchive bundle, error: %s", err)
 		}
-
-		// Bundles have the .pub-cache directory included, but would like to use the default location (HOME/.pub-cache),
-		// for consistency as Flutter deps are cached.
-		bundleSystemCachePath := filepath.Join(flutterSDKPath, ".pub-cache")
-		if err := os.RemoveAll(bundleSystemCachePath); err != nil {
-			failf("Failed to remove path(%s), error: %s", bundleSystemCachePath, err)
-		}
 	} else {
-		log.Infof("Cloning Flutter from the git repositry (https://github.com/flutter/flutter.git), selected branch/tag: %s", cfg.Version)
+		log.Infof("Cloning Flutter from the git repository (https://github.com/flutter/flutter.git)")
+		log.Infof("Selected branch/tag: %s", cfg.Version)
 
 		// repository name ('flutter') is in the path, will be checked out there
 		gitRepo, err := git.New(flutterSDKPath)

--- a/step.yml
+++ b/step.yml
@@ -75,6 +75,7 @@ inputs:
 
   - is_debug: "false"
     opts:
+      category: Debug
       title: Print debug information
       summary: If enabled will run flutter doctor and print value of PATH eniroment variable.
       description: If enabled will run flutter doctor and print value of PATH eniroment variable.

--- a/step.yml
+++ b/step.yml
@@ -1,12 +1,9 @@
 title: Flutter Install
-summary: |-
-  This step will git clone the selected branch or tag of the official Flutter repository and will run the initial setup of the Flutter SDK.
-
-  Use this step *before* the cache-pull step to make sure Flutter dependency caching works correctly.
+summary: This step will git clone the selected branch or tag of the official Flutter repository and will run the initial setup of the Flutter SDK. Use this step *before* the cache-pull step to make sure pub caching is working correctly.
 description: |-
   This step will git clone the selected branch or tag of the official Flutter repository and will run the initial setup of the Flutter SDK.
 
-  Use this step *before* the cache-pull step to make sure Flutter dependency caching works correctly.
+  Use this step *before* the cache-pull step to make sure pub caching is working correctly.
 website: https://github.com/bitrise-steplib/bitrise-step-flutter-installer
 source_code_url: https://github.com/bitrise-steplib/bitrise-step-flutter-installer
 support_url: https://github.com/bitrise-steplib/bitrise-step-flutter-installer/issues

--- a/step.yml
+++ b/step.yml
@@ -1,6 +1,12 @@
 title: Flutter Install
-summary: This step will git clone the selected branch or tag of the official Flutter repository and will run the initial setup of the Flutter SDK.
-description: This step will git clone the selected branch or tag of the official Flutter repository and will run the initial setup of the Flutter SDK.
+summary: |-
+  This step will git clone the selected branch or tag of the official Flutter repository and will run the initial setup of the Flutter SDK.
+
+  Use this step *before* the cache-pull step to make sure Flutter dependency caching works correctly.
+description: |-
+  This step will git clone the selected branch or tag of the official Flutter repository and will run the initial setup of the Flutter SDK.
+
+  Use this step *before* the cache-pull step to make sure Flutter dependency caching works correctly.
 website: https://github.com/bitrise-steplib/bitrise-step-flutter-installer
 source_code_url: https://github.com/bitrise-steplib/bitrise-step-flutter-installer
 support_url: https://github.com/bitrise-steplib/bitrise-step-flutter-installer/issues


### PR DESCRIPTION
Updated step description to point out that the step should be used before the cache-pull.

Not implemented:
Flutter Bundles have the .pub-cache directory included, but would like to use the default location (HOME/.pub-cache), for consistency as Flutter deps are cached.
So if the flutter cache path changes between runs, bitrise cache would not be on the correct paths.
The simples solution is to remove the cache directory inside the bundle.
Flutter (pub) uses PUB_CACHE env va if exists, otherwise falls back to FLUTTER_SDK_PATH/.pub-cache if exists, otherwise uses HOME/.pub-cache.