### PR TITLE
Prevent issues with new git version

### DIFF
--- a/bundle.go
+++ b/bundle.go
@@ -122,13 +122,14 @@ func downloadBundle(bundleURL string) (string, error) {
 
 func unarchiveBundle(tarPth, targetDir string) error {
 	// using -J to support tar.xz
+	// --no-same-owner to NOT preserve owners (default is to preserve, if ran as user 'root'),
+	// we want to set to current user as owner to prevent error due to git configuration (https://git-scm.com/docs/git-config/2.35.2#Documentation/git-config.txt-safedirectory)
 	tarCmd, err := command.NewWithParams("tar", "--no-same-owner", "-xJf", tarPth, "-C", targetDir)
 	if err != nil {
 		return fmt.Errorf("failed to create command, error: %s", err)
 	}
 
 	log.Donef("$ %s", tarCmd.PrintableCommandArgs())
-	fmt.Println()
 	out, err := tarCmd.RunAndReturnTrimmedCombinedOutput()
 	fmt.Println(out)
 	if err != nil {

--- a/bundle.go
+++ b/bundle.go
@@ -122,11 +122,13 @@ func downloadBundle(bundleURL string) (string, error) {
 
 func unarchiveBundle(tarPth, targetDir string) error {
 	// using -J to support tar.xz
-	tarCmd, err := command.NewWithParams("tar", "-xJf", tarPth, "-C", targetDir)
+	tarCmd, err := command.NewWithParams("tar", "--no-same-owner", "-xJf", tarPth, "-C", targetDir)
 	if err != nil {
 		return fmt.Errorf("failed to create command, error: %s", err)
 	}
 
+	log.Donef("$ %s", tarCmd.PrintableCommandArgs())
+	fmt.Println()
 	out, err := tarCmd.RunAndReturnTrimmedCombinedOutput()
 	fmt.Println(out)
 	if err != nil {
@@ -134,16 +136,6 @@ func unarchiveBundle(tarPth, targetDir string) error {
 			return fmt.Errorf("tar command failed: %s, out: %s", err, out)
 		}
 		return fmt.Errorf("failed to run tar command, error: %s", err)
-	}
-
-	if err := filepath.WalkDir(targetDir, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-
-		return os.Chown(path, os.Getuid(), os.Getegid())
-	}); err != nil {
-		return fmt.Errorf("failed to take ownership of flutter SDK directory: %w", err)
 	}
 
 	return nil

--- a/bundle.go
+++ b/bundle.go
@@ -136,5 +136,15 @@ func unarchiveBundle(tarPth, targetDir string) error {
 		return fmt.Errorf("failed to run tar command, error: %s", err)
 	}
 
+	if err := filepath.WalkDir(targetDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		return os.Chown(path, os.Getuid(), os.Getegid())
+	}); err != nil {
+		return fmt.Errorf("failed to take ownership of flutter SDK directory: %w", err)
+	}
+
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -121,10 +121,6 @@ to use the latest version from channel %s.`, requiredVersion)
 	sdkPathParent := filepath.Join(os.Getenv("HOME"), "flutter-sdk")
 	flutterSDKPath := filepath.Join(sdkPathParent, "flutter")
 
-	if cfg.IsDebug {
-		printDirOwner(sdkPathParent)
-	}
-
 	log.Printf("Cleaning SDK target path: %s", sdkPathParent)
 	if err := os.RemoveAll(sdkPathParent); err != nil {
 		failf("Failed to remove path(%s), error: %s", sdkPathParent, err)

--- a/main.go
+++ b/main.go
@@ -135,6 +135,7 @@ to use the latest version from channel %s.`, requiredVersion)
 	}
 
 	if bundleSpecified {
+		fmt.Println()
 		log.Infof("Downloading and unarchiving Flutter from installation bundle: %s", cfg.BundleURL)
 
 		if err := downloadAndUnarchiveBundle(cfg.BundleURL, sdkPathParent); err != nil {

--- a/main.go
+++ b/main.go
@@ -41,6 +41,15 @@ func runFlutterDoctor() error {
 	return nil
 }
 
+func printDirOwner(flutterSDKPath string) {
+	dirOwnerCmd := command.NewWithStandardOuts("ls", "-al", flutterSDKPath)
+	log.Donef("$ %s", dirOwnerCmd.PrintableCommandArgs())
+	fmt.Println()
+	if err := dirOwnerCmd.Run(); err != nil {
+		log.Warnf("Failed to run ls: %s", err)
+	}
+}
+
 func main() {
 	var cfg config
 	if err := stepconf.Parse(&cfg); err != nil {
@@ -112,6 +121,10 @@ to use the latest version from channel %s.`, requiredVersion)
 	sdkPathParent := filepath.Join(os.Getenv("HOME"), "flutter-sdk")
 	flutterSDKPath := filepath.Join(sdkPathParent, "flutter")
 
+	if cfg.IsDebug {
+		printDirOwner(sdkPathParent)
+	}
+
 	log.Printf("Cleaning SDK target path: %s", sdkPathParent)
 	if err := os.RemoveAll(sdkPathParent); err != nil {
 		failf("Failed to remove path(%s), error: %s", sdkPathParent, err)
@@ -169,12 +182,14 @@ to use the latest version from channel %s.`, requiredVersion)
 		}
 		log.Infof("Flutter binary path: %s", flutterBinPath)
 
-		treeCmd := command.New("tree", sdkPathParent).SetStdout(os.Stdout).SetStderr(os.Stderr)
+		treeCmd := command.New("tree", "-L", "3", sdkPathParent).SetStdout(os.Stdout).SetStderr(os.Stderr)
 		log.Donef("$ %s", treeCmd.PrintableCommandArgs())
 		fmt.Println()
 		if err := treeCmd.Run(); err != nil {
-			log.Warnf("Failed to run tree, error: %s", err)
+			log.Warnf("Failed to run tree command: %s", err)
 		}
+
+		printDirOwner(flutterSDKPath)
 	}
 
 	fmt.Println()


### PR DESCRIPTION
### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
Requires a *PATCH* [version update](https://semver.org/)

### Context

Fox for issue introduced by git security fix (https://github.blog/2022-04-12-git-security-vulnerability-announced/)
```
fatal: unsafe repository ('/root/flutter-sdk/flutter' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /root/flutter-sdk/flutter
```
Example failed build: https://app.bitrise.io/build/ebcd5b08-f9ae-4baa-95e2-3c3cfee77569

Resolves: https://bitrise.atlassian.net/browse/STEP-1981

### Changes

- Added `-no-same-owner` param to tar.
- reduced tree command depth
### Investigation details

When flutter is downloaded as a bundle, the owners of the files were preserved (when running as root due to the behavior of the _tar_ command). This is not the expected behavior anyway, and could cause other issues too.
<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

Reduced depth of tree command (used for debugging only) to be less verbose.
<!-- Please list decisions that were made for this change. -->
