### PR TITLE
fix #39: issue where flutter install command would fail to use fvm even when available 

### DIFF
--- a/flutter_install_type.go
+++ b/flutter_install_type.go
@@ -169,7 +169,7 @@ func (f *FlutterInstaller) fvmIsAvailable() (bool, string) {
 	}
 	f.Debugf("fvm version: %s", versionOut)
 
-	return true, ""
+	return true, versionOut
 }
 
 // fvmParseVersionAndFeatures parses the FVM version output and determines if it supports features introduced in specific versions.


### PR DESCRIPTION
### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Issue
https://github.com/bitrise-steplib/bitrise-step-flutter-installer/issues/39

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH*

### Context

The Flutter Install step is currently not supporting FVM correctly. This MR addresses an issue with processing the available fvm version.

### Changes

Updated the `fvmIsAvailable` function to correctly return the output from `fvm --version`.

### Investigation details

No alternative solutions were considered.

### Decisions

Return the version output by `fvm --version` from the `fvmIsAvailable` method.
